### PR TITLE
chore: conference-monolith to 0.0.5

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -2,6 +2,9 @@ dependencies:
 - name: conference-agenda
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.22
+- name: conference-monolith
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.5
 - name: conference-site
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.10


### PR DESCRIPTION
chore: Promote conference-monolith to version 0.0.5