### PR TITLE
chore: conference-monolith to 0.0.9

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -5,6 +5,9 @@ dependencies:
 - name: conference-agenda
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.23
+- name: conference-monolith
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.9
 - name: conference-site
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.13


### PR DESCRIPTION
chore: Promote conference-monolith to version 0.0.9